### PR TITLE
fix:plugin 3.4.2 版本

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,6 @@ growingAutotracker {
     analyticsAdapter {
         firebaseAnalytics false
         googleAnalytics false
-        sensorAnalytics false
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.6.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
 
-    implementation 'com.growingio.android:autotracker-cdp:3.4.0-SNAPSHOT'
+    implementation 'com.growingio.android:autotracker-cdp:3.4.1'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/src/main/java/com/growingio/android/plugin/menuitem/MenuItemActivity.java
+++ b/app/src/main/java/com/growingio/android/plugin/menuitem/MenuItemActivity.java
@@ -68,6 +68,7 @@ public class MenuItemActivity extends AppCompatActivity {
                 popupMenu.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
                     @Override
                     public boolean onMenuItemClick(MenuItem item) {
+
                         return true;
                     }
                 });

--- a/autotracker-gradle-plugin/build.gradle.kts
+++ b/autotracker-gradle-plugin/build.gradle.kts
@@ -21,8 +21,8 @@ val testPluginImplementation: Configuration by configurations.creating {
 }
 
 ext {
-    set("releaseVersion", "3.4.1")
-    set("releaseVersionCode", 30401)
+    set("releaseVersion", "3.4.2")
+    set("releaseVersionCode", 30402)
     set("agp_version", "7.2.1")
     set("low_agp_version", "4.2.2")
     set("kotlin_version", "1.6.21")

--- a/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/AutoTrackerExtension.kt
+++ b/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/AutoTrackerExtension.kt
@@ -18,6 +18,7 @@ package com.growingio.android.plugin
 
 import org.gradle.api.Action
 import org.gradle.internal.reflect.Instantiator
+import java.io.Serializable
 
 /**
  * <p>
@@ -25,7 +26,7 @@ import org.gradle.internal.reflect.Instantiator
  * @author cpacm 2022/3/30
  */
 
-open class AutoTrackerExtension (var instantiator: Instantiator) {
+open class AutoTrackerExtension(var instantiator: Instantiator) {
 
     var logEnabled = false
 
@@ -40,16 +41,21 @@ open class AutoTrackerExtension (var instantiator: Instantiator) {
     var analyticsAdapter: AnalyticsAdapter? = null
 
     open fun analyticsAdapter(configuration: Action<in AnalyticsAdapter>) {
-        analyticsAdapter = (instantiator.newInstance(AnalyticsAdapter::class.java)).apply { configuration.execute(this) }
+        analyticsAdapter =
+            (instantiator.newInstance(AnalyticsAdapter::class.java)).apply { configuration.execute(this) }
     }
 }
 
 //用于配置是否可以对第三方分析服务进行适配
-open class AnalyticsAdapter (
+open class AnalyticsAdapter(
     // 适配 FirebaseAnalytics
     var firebaseAnalytics: Boolean = false,
     // 适配 GoogleAnalytics
     var googleAnalytics: Boolean = false,
     // 适配 sensorAnalytics
     var sensorAnalytics: Boolean = false
-)
+) : Serializable {
+    fun toArray(): Array<Boolean> {
+        return arrayOf(firebaseAnalytics, googleAnalytics, sensorAnalytics)
+    }
+}

--- a/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/AutoTrackerExtension.kt
+++ b/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/AutoTrackerExtension.kt
@@ -55,7 +55,8 @@ open class AnalyticsAdapter(
     // 适配 sensorAnalytics
     var sensorAnalytics: Boolean = false
 ) : Serializable {
-    fun toArray(): Array<Boolean> {
-        return arrayOf(firebaseAnalytics, googleAnalytics, sensorAnalytics)
+
+    override fun toString(): String {
+        return "$firebaseAnalytics+$googleAnalytics+$sensorAnalytics"
     }
 }

--- a/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/AutoTrackerPlugin.kt
+++ b/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/AutoTrackerPlugin.kt
@@ -81,7 +81,7 @@ class AutoTrackerPlugin @Inject constructor(val instantiator: Instantiator) : Pl
                 params.excludePackages.set(gioExtension.excludePackages ?: arrayOf())
                 params.includePackages.set(gioExtension.includePackages ?: arrayOf())
                 params.injectClasses.set(gioExtension.injectClasses ?: arrayOf())
-                params.analytics.set(gioExtension.analyticsAdapter)
+                params.analytics.set(gioExtension.analyticsAdapter ?: AnalyticsAdapter())
             }
             androidComponent.setAsmFramesComputationMode(FramesComputationMode.COMPUTE_FRAMES_FOR_INSTRUMENTED_METHODS)
         }

--- a/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/AutoTrackerPlugin.kt
+++ b/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/AutoTrackerPlugin.kt
@@ -39,14 +39,7 @@ import javax.inject.Inject
  *
  * @author cpacm 2022/3/30
  */
-abstract class AutoTrackerPlugin : Plugin<Project> {
-
-    private var instantiator: Instantiator
-
-    @Inject
-    constructor(instantiator: Instantiator) {
-        this.instantiator = instantiator
-    }
+class AutoTrackerPlugin @Inject constructor(val instantiator: Instantiator) : Plugin<Project> {
 
     override fun apply(project: Project) {
 

--- a/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/AutoTrackerPlugin.kt
+++ b/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/AutoTrackerPlugin.kt
@@ -81,7 +81,7 @@ class AutoTrackerPlugin @Inject constructor(val instantiator: Instantiator) : Pl
                 params.excludePackages.set(gioExtension.excludePackages ?: arrayOf())
                 params.includePackages.set(gioExtension.includePackages ?: arrayOf())
                 params.injectClasses.set(gioExtension.injectClasses ?: arrayOf())
-                params.analytics.set(gioExtension.analyticsAdapter?.toArray())
+                params.analytics.set(gioExtension.analyticsAdapter)
             }
             androidComponent.setAsmFramesComputationMode(FramesComputationMode.COMPUTE_FRAMES_FOR_INSTRUMENTED_METHODS)
         }

--- a/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/AutoTrackerPlugin.kt
+++ b/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/AutoTrackerPlugin.kt
@@ -31,7 +31,6 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.internal.reflect.Instantiator
-import java.io.File
 import javax.inject.Inject
 
 /**
@@ -77,10 +76,12 @@ class AutoTrackerPlugin @Inject constructor(val instantiator: Instantiator) : Pl
                 classVisitorFactoryImplClass = AutoTrackerFactory::class.java,
                 scope = InstrumentationScope.ALL
             ) { params ->
-                val classesDir = File(project.buildDir, "intermediates/javac/${androidComponent.name}/classes")
-                params.additionalClassesDir.set(classesDir)
+                //val classesDir = File(project.buildDir, "intermediates/javac/${androidComponent.name}/classes")
+                //params.additionalClassesDir.set(classesDir)
                 params.excludePackages.set(gioExtension.excludePackages ?: arrayOf())
                 params.includePackages.set(gioExtension.includePackages ?: arrayOf())
+                params.injectClasses.set(gioExtension.injectClasses ?: arrayOf())
+                params.analytics.set(gioExtension.analyticsAdapter?.toArray())
             }
             androidComponent.setAsmFramesComputationMode(FramesComputationMode.COMPUTE_FRAMES_FOR_INSTRUMENTED_METHODS)
         }

--- a/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/hook/HookInjectorClass.kt
+++ b/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/hook/HookInjectorClass.kt
@@ -116,7 +116,7 @@ public object HookInjectorClass {
     TARGET_HOOK_CLASSES.add(HookData("com/google/android/gms/analytics/Tracker","setClientId","(Ljava/lang/String;)V","com/growingio/android/analytics/google/GoogleAnalyticsInjector","setClientId","(Lcom/google/android/gms/analytics/Tracker;Ljava/lang/String;)V",true))
     TARGET_HOOK_CLASSES.add(HookData("com/sensorsdata/analytics/android/sdk/SensorsDataAPI","disableSDK","()V","com/growingio/android/analytics/sensor/SensorAnalyticsInjector","disableSDK","()V",false))
     TARGET_HOOK_CLASSES.add(HookData("com/sensorsdata/analytics/android/sdk/SensorsDataAPI","enableSDK","()V","com/growingio/android/analytics/sensor/SensorAnalyticsInjector","enableSDK","()V",false))
-    TARGET_HOOK_CLASSES.add(HookData("com/sensorsdata/analytics/android/sdk/SensorsDataAPI","profileSet","(Lorg/json/JSONObject;)V","com/growingio/android/analytics/sensor/SensorAnalyticsInjector","profileSet","(Lorg/json/JSONObject;)V",false))
+    TARGET_HOOK_CLASSES.add(HookData("com/sensorsdata/analytics/android/sdk/AbstractSensorsDataAPI","trackEvent","(Lcom/sensorsdata/analytics/android/sdk/internal/beans/EventType;Ljava/lang/String;Lorg/json/JSONObject;Ljava/lang/String;)V","com/growingio/android/analytics/sensor/SensorAnalyticsInjector","trackEvent","(Lcom/sensorsdata/analytics/android/sdk/internal/beans/EventType;Ljava/lang/String;Lorg/json/JSONObject;Ljava/lang/String;)V",false))
     return TARGET_HOOK_CLASSES
   }
 

--- a/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/utils/FilterUtils.kt
+++ b/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/utils/FilterUtils.kt
@@ -125,6 +125,7 @@ fun initInjectClass(extension: AutoTrackerExtension) {
         }
         if (sensorAnalytics) {
             INCLUDED_PACKAGES.add("com.sensorsdata.analytics.android.sdk.SensorsDataAPI")
+            INCLUDED_PACKAGES.add("com.sensorsdata.analytics.android.sdk.AbstractSensorsDataAPI")
             DEFAULT_INJECT_CLASS.add("com.growingio.android.analytics.sensor.SensorAnalyticsInjector")
         }
     }

--- a/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/utils/FilterUtils.kt
+++ b/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/utils/FilterUtils.kt
@@ -117,16 +117,26 @@ fun initInjectClass(extension: AutoTrackerExtension) {
     }
 
     extension.analyticsAdapter?.apply {
-        if (firebaseAnalytics) {
-            DEFAULT_INJECT_CLASS.add("com.growingio.android.analytics.firebase.FirebaseAnalyticsInjector")
+        with("com.growingio.android.analytics.firebase.FirebaseAnalyticsInjector") {
+            if (firebaseAnalytics) DEFAULT_INJECT_CLASS.add(this)
+            else DEFAULT_INJECT_CLASS.remove(this)
         }
-        if (googleAnalytics) {
-            DEFAULT_INJECT_CLASS.add("com.growingio.android.analytics.google.GoogleAnalyticsInjector")
+
+        with("com.growingio.android.analytics.google.GoogleAnalyticsInjector") {
+            if (googleAnalytics) DEFAULT_INJECT_CLASS.add(this)
+            else DEFAULT_INJECT_CLASS.remove(this)
         }
-        if (sensorAnalytics) {
-            INCLUDED_PACKAGES.add("com.sensorsdata.analytics.android.sdk.SensorsDataAPI")
-            INCLUDED_PACKAGES.add("com.sensorsdata.analytics.android.sdk.AbstractSensorsDataAPI")
-            DEFAULT_INJECT_CLASS.add("com.growingio.android.analytics.sensor.SensorAnalyticsInjector")
+
+        with("com.growingio.android.analytics.sensor.SensorAnalyticsInjector") {
+            if (sensorAnalytics) {
+                DEFAULT_INJECT_CLASS.add(this)
+                INCLUDED_PACKAGES.add("com.sensorsdata.analytics.android.sdk.SensorsDataAPI")
+                INCLUDED_PACKAGES.add("com.sensorsdata.analytics.android.sdk.AbstractSensorsDataAPI")
+            } else {
+                DEFAULT_INJECT_CLASS.remove(this)
+                INCLUDED_PACKAGES.remove("com.sensorsdata.analytics.android.sdk.SensorsDataAPI")
+                INCLUDED_PACKAGES.remove("com.sensorsdata.analytics.android.sdk.AbstractSensorsDataAPI")
+            }
         }
     }
 

--- a/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/visitor/AutoTrackerFactory.kt
+++ b/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/visitor/AutoTrackerFactory.kt
@@ -20,6 +20,7 @@ import com.android.build.api.instrumentation.AsmClassVisitorFactory
 import com.android.build.api.instrumentation.ClassContext
 import com.android.build.api.instrumentation.ClassData
 import com.android.build.api.instrumentation.InstrumentationParameters
+import com.growingio.android.plugin.AnalyticsAdapter
 import com.growingio.android.plugin.transform.ClassContextCompat
 import com.growingio.android.plugin.utils.DEFAULT_INJECT_CLASS
 import com.growingio.android.plugin.utils.normalize
@@ -86,7 +87,7 @@ internal interface AutoTrackerParams : InstrumentationParameters {
      * that is used solely for that purpose.
      */
     @get:Input
-    val analytics: Property<Array<Boolean>>
+    val analytics: Property<AnalyticsAdapter>
 
     @get:Input
     val injectClasses: Property<Array<String>>

--- a/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/visitor/AutoTrackerFactory.kt
+++ b/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/visitor/AutoTrackerFactory.kt
@@ -24,10 +24,9 @@ import com.growingio.android.plugin.transform.ClassContextCompat
 import com.growingio.android.plugin.utils.DEFAULT_INJECT_CLASS
 import com.growingio.android.plugin.utils.normalize
 import com.growingio.android.plugin.utils.shouldClassModified
-import org.gradle.api.tasks.Internal
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
 import org.objectweb.asm.ClassVisitor
-import java.io.File
 
 /**
  * <p>
@@ -80,13 +79,22 @@ internal abstract class AutoTrackerFactory :
 
 
 internal interface AutoTrackerParams : InstrumentationParameters {
-    @get:Internal
-    val additionalClassesDir: Property<File>
 
-    @get:Internal
+    /**
+     * AGP will re-instrument dependencies, when the [InstrumentationParameters] changed
+     * https://issuetracker.google.com/issues/190082518#comment4. This is just a dummy parameter
+     * that is used solely for that purpose.
+     */
+    @get:Input
+    val analytics: Property<Array<Boolean>>
+
+    @get:Input
+    val injectClasses: Property<Array<String>>
+
+    @get:Input
     val excludePackages: Property<Array<String>>
 
-    @get:Internal
+    @get:Input
     val includePackages: Property<Array<String>>
 
 }

--- a/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/visitor/DesugarClassVisitor.kt
+++ b/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/visitor/DesugarClassVisitor.kt
@@ -159,9 +159,10 @@ internal class DesugarClassVisitor(
         api: Int,
         nmv: MethodVisitor,
         access: Int,
-        name: String?,
+        private val methodName: String?,//ASM6.0 hasn't inline name field,so we just create it.
         descriptor: String?,
-    ) : AdviceAdapter(api, nmv, access, name, descriptor) {
+    ) : AdviceAdapter(api, nmv, access, methodName, descriptor) {
+
 
         /**
          * 1. 生成的lambda方法一定会在 visitInvokeDynamicInsn 之后访问，故可直接在接下来的 onMethodEnter 和 onMethodExit 处理
@@ -268,7 +269,7 @@ internal class DesugarClassVisitor(
         }
 
         override fun onMethodEnter() {
-            val targetMethod = findTargetMethod(name, methodDesc) ?: return
+            val targetMethod = findTargetMethod(methodName ?: "", methodDesc) ?: return
             for (injectMethod in targetMethod.injectMethods) {
                 if (!injectMethod.isAfter && classIncluded(injectMethod.className)) {
                     visitInsn(ACONST_NULL)
@@ -286,7 +287,7 @@ internal class DesugarClassVisitor(
         }
 
         override fun onMethodExit(opcode: Int) {
-            val targetMethod = findTargetMethod(name, methodDesc) ?: return
+            val targetMethod = findTargetMethod(methodName ?: "", methodDesc) ?: return
             for (injectMethod in targetMethod.injectMethods) {
                 if (injectMethod.isAfter && classIncluded(injectMethod.className)) {
                     visitInsn(ACONST_NULL)

--- a/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/visitor/InjectSuperClassVisitor.kt
+++ b/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/visitor/InjectSuperClassVisitor.kt
@@ -137,10 +137,10 @@ internal class InjectSuperClassVisitor(
         api: Int,
         nmv: MethodVisitor,
         access: Int,
-        name: String?,
+        private val methodName: String?,//ASM6.0 hasn't inline name field,so we just create it.
         private val descriptor: String?,
         private val injectMethods: Set<InjectMethod>
-    ) : AdviceAdapter(api, nmv, access, name, descriptor) {
+    ) : AdviceAdapter(api, nmv, access, methodName, descriptor) {
 
         lateinit var localVariables: IntArray
 
@@ -154,7 +154,7 @@ internal class InjectSuperClassVisitor(
             }
 
             super.onMethodEnter()
-            injectMethod(this, injectMethods, false, name.toString(), methodDesc)
+            injectMethod(this, injectMethods, false, methodName.toString(), methodDesc)
         }
 
         override fun onMethodExit(opcode: Int) {
@@ -174,7 +174,7 @@ internal class InjectSuperClassVisitor(
                         Type.getObjectType(injectMethod.className),
                         Method(injectMethod.methodName, injectMethod.methodDesc)
                     )
-                    info("[SuperAfter] " + className.simpleClass() + "#" + name.toString() + methodDesc + " ==>Method Add: " + injectMethod.className.simpleClass() + "#" + injectMethod.methodName)
+                    info("[SuperAfter] " + className.simpleClass() + "#" + methodName.toString() + methodDesc + " ==>Method Add: " + injectMethod.className.simpleClass() + "#" + injectMethod.methodName)
                 }
             }
         }

--- a/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/visitor/InjectTargetClassVisitor.kt
+++ b/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/visitor/InjectTargetClassVisitor.kt
@@ -82,10 +82,10 @@ internal class InjectTargetClassVisitor(
         api: Int,
         nmv: MethodVisitor,
         access: Int,
-        name: String?,
+        private val methodName: String?,// ASM6.0 hasn't inline name field,so we just create it.
         private val descriptor: String?,
         private val injectMethods: Set<InjectMethod>
-    ) : AdviceAdapter(api, nmv, access, name, descriptor) {
+    ) : AdviceAdapter(api, nmv, access, methodName, descriptor) {
 
         lateinit var localVariables: IntArray;
 
@@ -135,7 +135,7 @@ internal class InjectTargetClassVisitor(
                         Type.getObjectType(injectMethod.className),
                         Method(injectMethod.methodName, injectMethod.methodDesc)
                     )
-                    info((if (isAfter) "[TargetAfter] " else "[TargetBefore] ") + className.simpleClass() + "#" + name.toString() + methodDesc + " ==>Method Add: " + injectMethod.className.simpleClass() + "#" + injectMethod.methodName)
+                    info((if (isAfter) "[TargetAfter] " else "[TargetBefore] ") + className.simpleClass() + "#" + methodName.toString() + methodDesc + " ==>Method Add: " + injectMethod.className.simpleClass() + "#" + injectMethod.methodName)
                 }
             }
         }

--- a/autotracker-gradle-plugin/src/test/kotlin/GradleTestRunner.kt
+++ b/autotracker-gradle-plugin/src/test/kotlin/GradleTestRunner.kt
@@ -41,7 +41,7 @@ class GradleTestRunner(val tempFolder: TemporaryFolder) {
         tempFolder.newFolder("src", "main", "java", "growingio")
         tempFolder.newFolder("src", "test", "java", "growingio")
         tempFolder.newFolder("src", "main", "res")
-        addDependencies("implementation 'com.growingio.android:autotracker-cdp:3.4.0-SNAPSHOT'")
+        addDependencies("implementation 'com.growingio.android:autotracker-cdp:3.4.1'")
     }
 
     // Adds project dependencies, e.g. "implementation <group>:<id>:<version>"

--- a/inject-descriptor/src/main/java/com/growingio/android/descriptor/SensorAnalyticsInjector.kt
+++ b/inject-descriptor/src/main/java/com/growingio/android/descriptor/SensorAnalyticsInjector.kt
@@ -49,17 +49,14 @@ interface SensorAnalyticsInjector {
     )
     fun enableSDK()
 
-
     @Inject(
-        targetClazz = "com/sensorsdata/analytics/android/sdk/SensorsDataAPI",
-        targetMethod = "profileSet",
-        targetMethodDesc = "(Lorg/json/JSONObject;)V",
-        injectMethod = "profileSet",
-        injectMethodDesc = "(Lorg/json/JSONObject;)V",
+        targetClazz = "com/sensorsdata/analytics/android/sdk/AbstractSensorsDataAPI",
+        targetMethod = "trackEvent",
+        targetMethodDesc = "(Lcom/sensorsdata/analytics/android/sdk/internal/beans/EventType;Ljava/lang/String;Lorg/json/JSONObject;Ljava/lang/String;)V",
+        injectMethod = "trackEvent",
+        injectMethodDesc = "(Lcom/sensorsdata/analytics/android/sdk/internal/beans/EventType;Ljava/lang/String;Lorg/json/JSONObject;Ljava/lang/String;)V",
         isAfter = false,
         type = 0
     )
-    fun profileSet()
-
-
+    fun trackEvent()
 }


### PR DESCRIPTION
## PR 内容

1. 在 gradle 5.2版本之前，不能使用 abstract plugin 作为插件编译
适配 ASM 6.0 ，使用AdviceAdapter时不再使用内部属性 name.
2. update sensors sdk adapter 
3. 添加 InstrumentationParam 参数以便插件检测到配置更新。
## 测试步骤

1. 使用 gradle 5.2版本之前，agp3.2.1 版本 测试
2. 测试插件参数开关后是否重新对第三方包进行编译

## 影响范围

## 是否属于重要变动？

- [ ] 是
- [x] 否

