### PR TITLE
fix: reusing slots will result in a VerifyError

### DIFF
--- a/autotracker-gradle-plugin/build.gradle.kts
+++ b/autotracker-gradle-plugin/build.gradle.kts
@@ -21,8 +21,8 @@ val testPluginImplementation: Configuration by configurations.creating {
 }
 
 ext {
-    set("releaseVersion", "3.4.6")
-    set("releaseVersionCode", 30406)
+    set("releaseVersion", "3.4.7")
+    set("releaseVersionCode", 30407)
     set("agp_version", "7.2.1")
     set("low_agp_version", "4.2.2")
     set("kotlin_version", "1.6.21")

--- a/autotracker-gradle-plugin/src/test/kotlin/GioDialogTransformTest.kt
+++ b/autotracker-gradle-plugin/src/test/kotlin/GioDialogTransformTest.kt
@@ -93,7 +93,7 @@ class GioDialogTransformTest {
             classReader.accept(classNode, 0)
             classNode.methods.find { it.name == "onClick" && it.desc == "(Landroid/content/DialogInterface;I)V" }.let {
                 assertThat(it).isNotNull()
-                assertThat(it?.instructions?.size()).isEqualTo(18)
+                assertThat(it?.instructions?.size()).isEqualTo(20)
                 it?.instructions?.iterator()?.asIterable()?.filterIsInstance(MethodInsnNode::class.java)
                     ?.first { method ->
                         assertThat(method.opcode).isEqualTo(Opcodes.INVOKESTATIC)
@@ -175,7 +175,7 @@ class GioDialogTransformTest {
             classReader.accept(classNode, 0)
             classNode.methods.find { it.name == "onClick" && it.desc == "(Landroid/content/DialogInterface;I)V" }.let {
                 assertThat(it).isNotNull()
-                assertThat(it?.instructions?.size()).isEqualTo(18)
+                assertThat(it?.instructions?.size()).isEqualTo(20)
                 it?.instructions?.iterator()?.asIterable()?.filterIsInstance(MethodInsnNode::class.java)
                     ?.first { method ->
                         assertThat(method.opcode).isEqualTo(Opcodes.INVOKESTATIC)
@@ -194,7 +194,7 @@ class GioDialogTransformTest {
             classReader.accept(classNode, 0)
             classNode.methods.find { it.name == "onClick" && it.desc == "(Landroid/content/DialogInterface;I)V" }.let {
                 assertThat(it).isNotNull()
-                assertThat(it?.instructions?.size()).isEqualTo(18)
+                assertThat(it?.instructions?.size()).isEqualTo(20)
                 it?.instructions?.iterator()?.asIterable()?.filterIsInstance(MethodInsnNode::class.java)
                     ?.first { method ->
                         assertThat(method.opcode).isEqualTo(Opcodes.INVOKESTATIC)
@@ -258,7 +258,7 @@ class GioDialogTransformTest {
             classReader.accept(classNode, 0)
             classNode.methods.find { it.name == "onClick" && it.desc == "(Landroid/content/DialogInterface;I)V" }.let {
                 assertThat(it).isNotNull()
-                assertThat(it?.instructions?.size()).isEqualTo(18)
+                assertThat(it?.instructions?.size()).isEqualTo(20)
                 it?.instructions?.iterator()?.asIterable()?.filterIsInstance(MethodInsnNode::class.java)
                     ?.first { method ->
                         assertThat(method.opcode).isEqualTo(Opcodes.INVOKESTATIC)
@@ -277,7 +277,7 @@ class GioDialogTransformTest {
             classReader.accept(classNode, 0)
             classNode.methods.find { it.name == "onClick" && it.desc == "(Landroid/content/DialogInterface;I)V" }.let {
                 assertThat(it).isNotNull()
-                assertThat(it?.instructions?.size()).isEqualTo(18)
+                assertThat(it?.instructions?.size()).isEqualTo(20)
                 it?.instructions?.iterator()?.asIterable()?.filterIsInstance(MethodInsnNode::class.java)
                     ?.first { method ->
                         assertThat(method.opcode).isEqualTo(Opcodes.INVOKESTATIC)

--- a/autotracker-gradle-plugin/src/test/kotlin/GioListTransformTest.kt
+++ b/autotracker-gradle-plugin/src/test/kotlin/GioListTransformTest.kt
@@ -123,7 +123,7 @@ class GioListTransformTest {
             classReader.accept(classNode, 0)
             classNode.methods.find { it.name == "onItemClick" && it.desc == "(Landroid/widget/AdapterView;Landroid/view/View;IJ)V" }.let {
                 assertThat(it).isNotNull()
-                assertThat(it?.instructions?.size()).isEqualTo(24)
+                assertThat(it?.instructions?.size()).isEqualTo(26)
                 it?.instructions?.iterator()?.asIterable()?.filterIsInstance(MethodInsnNode::class.java)
                     ?.first { method ->
                         assertThat(method.opcode).isEqualTo(Opcodes.INVOKESTATIC)
@@ -142,7 +142,7 @@ class GioListTransformTest {
             classReader.accept(classNode, 0)
             classNode.methods.find { it.name == "onItemSelected" && it.desc == "(Landroid/widget/AdapterView;Landroid/view/View;IJ)V" }.let {
                 assertThat(it).isNotNull()
-                assertThat(it?.instructions?.size()).isEqualTo(24)
+                assertThat(it?.instructions?.size()).isEqualTo(26)
                 it?.instructions?.iterator()?.asIterable()?.filterIsInstance(MethodInsnNode::class.java)
                     ?.first { method ->
                         assertThat(method.opcode).isEqualTo(Opcodes.INVOKESTATIC)
@@ -161,7 +161,7 @@ class GioListTransformTest {
             classReader.accept(classNode, 0)
             classNode.methods.find { it.name == "onGroupClick" && it.desc == "(Landroid/widget/ExpandableListView;Landroid/view/View;IJ)Z" }.let {
                 assertThat(it).isNotNull()
-                assertThat(it?.instructions?.size()).isEqualTo(25)
+                assertThat(it?.instructions?.size()).isEqualTo(27)
                 it?.instructions?.iterator()?.asIterable()?.filterIsInstance(MethodInsnNode::class.java)
                     ?.first { method ->
                         assertThat(method.opcode).isEqualTo(Opcodes.INVOKESTATIC)
@@ -180,7 +180,7 @@ class GioListTransformTest {
             classReader.accept(classNode, 0)
             classNode.methods.find { it.name == "onChildClick" && it.desc == "(Landroid/widget/ExpandableListView;Landroid/view/View;IIJ)Z" }.let {
                 assertThat(it).isNotNull()
-                assertThat(it?.instructions?.size()).isEqualTo(28)
+                assertThat(it?.instructions?.size()).isEqualTo(30)
                 it?.instructions?.iterator()?.asIterable()?.filterIsInstance(MethodInsnNode::class.java)
                     ?.first { method ->
                         assertThat(method.opcode).isEqualTo(Opcodes.INVOKESTATIC)

--- a/autotracker-gradle-plugin/src/test/kotlin/GioMenuItemTransformTest.kt
+++ b/autotracker-gradle-plugin/src/test/kotlin/GioMenuItemTransformTest.kt
@@ -110,7 +110,7 @@ class GioMenuItemTransformTest {
             classReader.accept(classNode, 0)
             classNode.methods.find { it.name == "onMenuItemClick" && it.desc == "(Landroid/view/MenuItem;)Z" }.let {
                 assertThat(it).isNotNull()
-                assertThat(it?.instructions?.size()).isEqualTo(10)
+                assertThat(it?.instructions?.size()).isEqualTo(12)
                 it?.instructions?.iterator()?.asIterable()?.filterIsInstance(MethodInsnNode::class.java)
                     ?.first { method ->
                         assertThat(method.opcode).isEqualTo(Opcodes.INVOKESTATIC)
@@ -129,7 +129,7 @@ class GioMenuItemTransformTest {
             classReader.accept(classNode, 0)
             classNode.methods.find { it.name == "onMenuItemClick" && it.desc == "(Landroid/view/MenuItem;)Z" }.let {
                 assertThat(it).isNotNull()
-                assertThat(it?.instructions?.size()).isEqualTo(10)
+                assertThat(it?.instructions?.size()).isEqualTo(12)
                 it?.instructions?.iterator()?.asIterable()?.filterIsInstance(MethodInsnNode::class.java)
                     ?.first { method ->
                         assertThat(method.opcode).isEqualTo(Opcodes.INVOKESTATIC)
@@ -148,7 +148,7 @@ class GioMenuItemTransformTest {
             classReader.accept(classNode, 0)
             classNode.methods.find { it.name == "onMenuItemClick" && it.desc == "(Landroid/view/MenuItem;)Z" }.let {
                 assertThat(it).isNotNull()
-                assertThat(it?.instructions?.size()).isEqualTo(10)
+                assertThat(it?.instructions?.size()).isEqualTo(12)
                 it?.instructions?.iterator()?.asIterable()?.filterIsInstance(MethodInsnNode::class.java)
                     ?.first { method ->
                         assertThat(method.opcode).isEqualTo(Opcodes.INVOKESTATIC)

--- a/autotracker-gradle-plugin/src/test/kotlin/GioViewClickTransformTest.kt
+++ b/autotracker-gradle-plugin/src/test/kotlin/GioViewClickTransformTest.kt
@@ -137,7 +137,7 @@ class GioViewClickTransformTest {
             classReader.accept(classNode, 0)
             classNode.methods.find { it.name == "onClick" && it.desc == "(Landroid/view/View;)V" }.let {
                 assertThat(it).isNotNull()
-                assertThat(it?.instructions?.size()).isEqualTo(15)
+                assertThat(it?.instructions?.size()).isEqualTo(17)
                 it?.instructions?.iterator()?.asIterable()?.filterIsInstance(MethodInsnNode::class.java)
                     ?.first { method ->
                         assertThat(method.opcode).isEqualTo(Opcodes.INVOKESTATIC)
@@ -156,7 +156,7 @@ class GioViewClickTransformTest {
             classReader.accept(classNode, 0)
             classNode.methods.find { it.name == "onStopTrackingTouch" && it.desc == "(Landroid/widget/SeekBar;)V" }.let {
                 assertThat(it).isNotNull()
-                assertThat(it?.instructions?.size()).isEqualTo(15)
+                assertThat(it?.instructions?.size()).isEqualTo(17)
                 it?.instructions?.iterator()?.asIterable()?.filterIsInstance(MethodInsnNode::class.java)
                     ?.first { method ->
                         assertThat(method.opcode).isEqualTo(Opcodes.INVOKESTATIC)
@@ -175,7 +175,7 @@ class GioViewClickTransformTest {
             classReader.accept(classNode, 0)
             classNode.methods.find { it.name == "onCheckedChanged" && it.desc == "(Landroid/widget/RadioGroup;I)V" }.let {
                 assertThat(it).isNotNull()
-                assertThat(it?.instructions?.size()).isEqualTo(18)
+                assertThat(it?.instructions?.size()).isEqualTo(20)
                 it?.instructions?.iterator()?.asIterable()?.filterIsInstance(MethodInsnNode::class.java)
                     ?.first { method ->
                         assertThat(method.opcode).isEqualTo(Opcodes.INVOKESTATIC)
@@ -194,7 +194,7 @@ class GioViewClickTransformTest {
             classReader.accept(classNode, 0)
             classNode.methods.find { it.name == "onRatingChanged" && it.desc == "(Landroid/widget/RatingBar;FZ)V" }.let {
                 assertThat(it).isNotNull()
-                assertThat(it?.instructions?.size()).isEqualTo(21)
+                assertThat(it?.instructions?.size()).isEqualTo(23)
                 it?.instructions?.iterator()?.asIterable()?.filterIsInstance(MethodInsnNode::class.java)
                     ?.first { method ->
                         assertThat(method.opcode).isEqualTo(Opcodes.INVOKESTATIC)
@@ -213,7 +213,7 @@ class GioViewClickTransformTest {
             classReader.accept(classNode, 0)
             classNode.methods.find { it.name == "onCheckedChanged" && it.desc == "(Landroid/widget/CompoundButton;Z)V" }.let {
                 assertThat(it).isNotNull()
-                assertThat(it?.instructions?.size()).isEqualTo(18)
+                assertThat(it?.instructions?.size()).isEqualTo(20)
                 it?.instructions?.iterator()?.asIterable()?.filterIsInstance(MethodInsnNode::class.java)
                     ?.first { method ->
                         assertThat(method.opcode).isEqualTo(Opcodes.INVOKESTATIC)


### PR DESCRIPTION
## PR 内容
当注入的class已经是经过r8等工具优化后的，可能存在slot复用，从而减少操作数栈和局部变量表大小
这种情况下需要提前存储this以及局部变量，等最后合并dex时再交由r8优化


## 测试步骤
依赖 com.google.android.gms:play-services-basement:18.1.0
处理其com.google.android.gms.common.api.internal.zzd#onResume方法
运行时不出现VerifyError

复现步骤，在项目中集成SDK，并且implementation 'com.google.android.gms:play-services-basement:18.1.0'
在能执行到的位置，比如首页的onCreate中，调用new com.google.android.gms.common.api.internal.zzd.onResume(); 即可复现该问题


## 影响范围

<!-- 请描述你的PR能造成的影响范围. -->


## 是否属于重要变动？

- [ ] 是
- [x] 否


## 其他信息


