### PR TITLE
fix: agp is unable to handle the classes under the default package co…

### DIFF
--- a/app/src/main/java/CustomDialog.kt
+++ b/app/src/main/java/CustomDialog.kt
@@ -1,0 +1,10 @@
+import android.view.View
+
+class CustomDialog {
+    private var view: View? = null
+
+    public fun setListener() {
+        view?.setOnClickListener {
+        }
+    }
+}

--- a/autotracker-gradle-plugin/agp-wrapper-impl/src/main/kotlin/com/growingio/android/plugin/visitor/DesugarClassVisitor.kt
+++ b/autotracker-gradle-plugin/agp-wrapper-impl/src/main/kotlin/com/growingio/android/plugin/visitor/DesugarClassVisitor.kt
@@ -21,6 +21,7 @@ import com.growingio.android.plugin.hook.TargetMethod
 import com.growingio.android.plugin.util.ClassContextCompat
 import com.growingio.android.plugin.util.info
 import com.growingio.android.plugin.util.unNormalize
+import com.growingio.android.plugin.util.normalize
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.Handle
 import org.objectweb.asm.MethodVisitor
@@ -52,6 +53,7 @@ class DesugarClassVisitor(
         interfaces: Array<out String>?
     ) {
         super.visit(version, access, name, signature, superName, interfaces)
+        if (!name.isNullOrBlank()) className = normalize(name)
     }
 
     override fun visitMethod(

--- a/autotracker-gradle-plugin/agp-wrapper/src/main/kotlin/com/growingio/android/plugin/util/ClassContextCompat.kt
+++ b/autotracker-gradle-plugin/agp-wrapper/src/main/kotlin/com/growingio/android/plugin/util/ClassContextCompat.kt
@@ -6,7 +6,7 @@ package com.growingio.android.plugin.util
  * @author cpacm 2023/8/18
  */
 interface ClassContextCompat {
-    val className: String
+    var className: String
 
     fun isAssignable(subClazz: String, superClazz: String): Boolean
 

--- a/autotracker-gradle-plugin/build.gradle.kts
+++ b/autotracker-gradle-plugin/build.gradle.kts
@@ -3,8 +3,8 @@ buildscript {
         set("kotlin_version", "1.8.20")
         set("agp_version", "8.1.0")
         set("low_agp_version", "4.2.2")
-        set("releaseVersion", "4.3.0")
-        set("releaseVersionCode", 40300)
+        set("releaseVersion", "4.3.1-SNAPSHOT")
+        set("releaseVersionCode", 40301)
     }
 }
 

--- a/autotracker-gradle-plugin/saas-gradle-plugin/build.gradle.kts
+++ b/autotracker-gradle-plugin/saas-gradle-plugin/build.gradle.kts
@@ -1,7 +1,7 @@
 buildscript {
     extra.apply {
-        set("saasVersion", "2.10.2")
-        set("saasVersionCode", "21002")
+        set("saasVersion", "2.10.3-SNAPSHOT")
+        set("saasVersionCode", "21003")
     }
 }
 

--- a/autotracker-gradle-plugin/saas-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/visitor/SaasAutoTrackerFactory.kt
+++ b/autotracker-gradle-plugin/saas-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/visitor/SaasAutoTrackerFactory.kt
@@ -39,7 +39,7 @@ internal abstract class SaasAutoTrackerFactory :
 
     override fun createClassVisitor(classContext: ClassContext, nextClassVisitor: ClassVisitor): ClassVisitor {
         val classContextCompat = object : ClassContextCompat {
-            override val className = classContext.currentClassData.className
+            override var className = classContext.currentClassData.className
 
             override fun isAssignable(subClazz: String, superClazz: String): Boolean {
                 return classContext.loadClassData(normalize(subClazz))?.let {

--- a/autotracker-gradle-plugin/saas-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/visitor/SaasAutoTrackerTransform.kt
+++ b/autotracker-gradle-plugin/saas-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/visitor/SaasAutoTrackerTransform.kt
@@ -64,7 +64,7 @@ internal class SaasAutoTrackerTransform(
             val apiVersion = autoTrackerWriter.getApi()
 
             val classContextCompat = object : ClassContextCompat {
-                override val className = classReader.className
+                override var className = classReader.className
                 override fun isAssignable(subClazz: String, superClazz: String): Boolean {
                     return context.klassPool.get(superClazz).isAssignableFrom(subClazz)
                 }

--- a/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/giokit/GioKitCodeVisitor.kt
+++ b/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/giokit/GioKitCodeVisitor.kt
@@ -59,6 +59,7 @@ internal class GioKitCodeVisitor(
         interfaces: Array<out String>?
     ) {
         super.visit(version, access, name, signature, superName, interfaces)
+        if (!name.isNullOrBlank()) context.className = normalize(name)
     }
 
     override fun visitMethod(

--- a/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/giokit/GioKitInjectVisitor.kt
+++ b/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/giokit/GioKitInjectVisitor.kt
@@ -1,6 +1,7 @@
 package com.growingio.android.plugin.giokit
 
 import com.growingio.android.plugin.util.ClassContextCompat
+import com.growingio.android.plugin.util.normalize
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.MethodVisitor
 
@@ -15,6 +16,18 @@ internal class GioKitInjectVisitor(
     private val classContext: ClassContextCompat,
     private val giokitParams: GioKitParams
 ) : ClassVisitor(api, ncv), ClassContextCompat by classContext {
+
+    override fun visit(
+        version: Int,
+        access: Int,
+        name: String?,
+        signature: String?,
+        superName: String?,
+        interfaces: Array<out String>?
+    ) {
+        super.visit(version, access, name, signature, superName, interfaces)
+        if (!name.isNullOrBlank()) classContext.className = normalize(name)
+    }
 
     override fun visitMethod(
         access: Int,

--- a/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/visitor/AutoTrackerFactory.kt
+++ b/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/visitor/AutoTrackerFactory.kt
@@ -46,7 +46,9 @@ internal abstract class AutoTrackerFactory :
 
     override fun createClassVisitor(classContext: ClassContext, nextClassVisitor: ClassVisitor): ClassVisitor {
         val classContextCompat = object : ClassContextCompat {
-            override val className = classContext.currentClassData.className
+            // AsmInstrumentationManager#instrumentClassesFromDirectoryToDirectory 移除文件名方法无包名（相对路径为当前路径）时不生效
+            // 非日志输出时，尽可能使用visit方法参数中返回的name
+            override var className = classContext.currentClassData.className
 
             override fun isAssignable(subClazz: String, superClazz: String): Boolean {
                 return classContext.loadClassData(normalize(subClazz))?.let {

--- a/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/visitor/AutoTrackerTransform.kt
+++ b/autotracker-gradle-plugin/src/main/kotlin/com/growingio/android/plugin/visitor/AutoTrackerTransform.kt
@@ -98,7 +98,7 @@ internal class AutoTrackerTransform(
             val apiVersion = autoTrackerWriter.getApi()
 
             val classContextCompat = object : ClassContextCompat {
-                override val className = classReader.className
+                override var className = classReader.className
                 override fun isAssignable(subClazz: String, superClazz: String): Boolean {
                     return context.klassPool.get(superClazz).isAssignableFrom(subClazz)
                 }

--- a/autotracker-gradle-plugin/src/test/kotlin/GradleTestRunner.kt
+++ b/autotracker-gradle-plugin/src/test/kotlin/GradleTestRunner.kt
@@ -41,7 +41,7 @@ class GradleTestRunner(val tempFolder: TemporaryFolder) {
         tempFolder.newFolder("src", "main", "java", "growingio")
         tempFolder.newFolder("src", "test", "java", "growingio")
         tempFolder.newFolder("src", "main", "res")
-        addDependencies("implementation 'com.growingio.android:autotracker:4.0.0-SNAPSHOT'")
+        addDependencies("implementation 'com.growingio.android:autotracker:4.3.0'")
     }
 
     // Adds project dependencies, e.g. "implementation <group>:<id>:<version>"
@@ -223,7 +223,8 @@ class GradleTestRunner(val tempFolder: TemporaryFolder) {
         .withArguments(listOf("--stacktrace", "assembleDebug") + additionalTasks)
         .withPluginClasspath()
         .withDebug(true) // Add this line to enable attaching a debugger to the gradle test invocation
-        .forwardOutput()
+        .forwardStdError(System.err.writer())
+        .forwardStdOutput(System.out.writer())
 
     // Data class representing a Gradle Test run result.
     data class Result(


### PR DESCRIPTION
## PR 内容
1. AGP的ASMFactory在处理时逻辑如下，当类文件无包名时packageName的文件名无法被删除
即默认路径下的CustomDialog 相关className 为 ClassDialog.class.ClassDialog
```kotlin
override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
    val relativePath = inputPath.relativize(file)
    val fileName = relativePath.fileName.toString()
    val outputFile = outputDir.resolve(relativePath.toString())
    outputFile.parentFile.mkdirs()

    if (includeFileInInstrumentation(relativePath.toString())) {
        instrumentClassToDir(
            packageName = relativePath.toString()
                .removeSuffix(File.separatorChar + fileName)
                .replace(File.separatorChar, '.'),
            className = fileName.removeSuffix(SdkConstants.DOT_CLASS),
            classFile = file.toFile(),
            outputFile = outputFile
        )
    } else {
        FileUtils.copyFile(file.toFile(), outputFile)
    }
    return FileVisitResult.CONTINUE
}
```
2. 修改单测中依赖的SDK版本为release版本，snapshot在snoatype上当发布release时会清理对应snapshot版本

## 测试步骤

默认路径下类注入后字节码不会存在异常


## 影响范围

<!-- 请描述你的PR能造成的影响范围. -->


## 是否属于重要变动？

- [ ] 是
- [x] 否


## 其他信息


